### PR TITLE
Added header to Peter's Roadmap page

### DIFF
--- a/site/src/pages/RoadmapPage/Header.jsx
+++ b/site/src/pages/RoadmapPage/Header.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import "./Header.scss";
-import { Button, Icon } from "semantic-ui-react";
+import { Button } from "semantic-ui-react";
 
 const Header = ({ courseCount, unitCount }) => (
   <div className="header">
-    <span className="planner-stats">
+    <span id="planner-stats">
       Total: <span id="course-count">{courseCount}</span> courses,{" "}
       <span id="unit-count">{unitCount}</span> units
     </span>
-    <span className="title">
+    <span id="title">
       <h2>Peter's Roadmap</h2>
     </span>
     <Button.Group>

--- a/site/src/pages/RoadmapPage/Header.jsx
+++ b/site/src/pages/RoadmapPage/Header.jsx
@@ -1,9 +1,20 @@
 import React from "react";
 import "./Header.scss";
+import { Button, Icon } from "semantic-ui-react";
 
-const Header = () => (
+const Header = ({ courseCount, unitCount }) => (
   <div className="header">
-    <h1>Header</h1>
+    <span className="planner-stats">
+      Total: <span id="course-count">{courseCount}</span> courses,{" "}
+      <span id="unit-count">{unitCount}</span> units
+    </span>
+    <span className="title">
+      <h2>Peter's Roadmap</h2>
+    </span>
+    <Button.Group>
+      <Button className="header-btn" icon="undo" content="Undo" />
+      <Button className="header-btn" icon="download" content="Export" />
+    </Button.Group>
   </div>
 );
 

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -1,5 +1,35 @@
+* {
+  --zot-blue: #2484c6;
+  --aldrich-blue: #74d1f6;
+  --ring-road-white: #ffffff;
+  --petr-gray: #808080;
+}
+
 .header {
-  background: gray;
-  height: 6vh;
+  background: linear-gradient(to right, var(--zot-blue), var(--aldrich-blue));
+  height: 3rem;
+  color: var(--ring-road-white);
   text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.planner-stats {
+  margin-left: 1rem;
+}
+
+#course-count,
+#unit-count {
+  font-weight: bold;
+}
+
+.ui.button.header-btn {
+  color: var(--ring-road-white);
+  background-color: transparent;
+}
+
+.download.icon,
+.undo.icon {
+  padding-right: 20px;
 }

--- a/site/src/pages/RoadmapPage/Header.scss
+++ b/site/src/pages/RoadmapPage/Header.scss
@@ -15,7 +15,7 @@
   align-items: center;
 }
 
-.planner-stats {
+#planner-stats {
   margin-left: 1rem;
 }
 

--- a/site/src/pages/RoadmapPage/PlannerPage.jsx
+++ b/site/src/pages/RoadmapPage/PlannerPage.jsx
@@ -1,14 +1,17 @@
-import React from 'react'
+import React, { useState } from "react";
 import "./PlannerPage.scss";
-import Header from "./Header.jsx"
+import Header from "./Header.jsx";
 
 function PlannerPage() {
+  const [courseCount, setCourseCount] = useState(0);
+  const [unitCount, setUnitCount] = useState(0);
+
   return (
     <div className="planner-page">
-      <Header/>
+      <Header courseCount={courseCount} unitCount={unitCount} />
       <h1>Planner Page</h1>
     </div>
-  )
+  );
 }
 
-export default PlannerPage
+export default PlannerPage;


### PR DESCRIPTION
I added the header to the Peter's Roadmap page, which includes the course + unit count, title, and export + undo buttons.

<img width="1440" alt="Screen Shot 2021-02-10 at 5 15 55 PM" src="https://user-images.githubusercontent.com/39716137/107593465-3b71ae00-6bc4-11eb-97fe-b70b00cf63c6.png">

