### PR TITLE
Fix footer API link

### DIFF
--- a/site/src/component/Footer/Footer.tsx
+++ b/site/src/component/Footer/Footer.tsx
@@ -7,7 +7,7 @@ const Footer: FC = (props) => {
             <footer className='footer'>
                 <div>
                     <a href='https://github.com/icssc-projects'>Github</a>
-                    <a href='/api/v1'>API</a>
+                    <a href='https://api.peterportal.org'>API</a>
                     <a href='/about'>About</a>
                     <a href='/about#team'>Team</a>
                     <a href='/legal'>Terms</a>


### PR DESCRIPTION
## Description
This fixes the footer API link to redirect to the correct api website. 
The link before was a 404.

## Steps to verify/test this change:
Opened https://api.peterportal.org in new tab and verified that the link works