### PR TITLE
Updated icons from `react-icon` to semantic ui icons

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -30,7 +30,6 @@
     "react-dom": "^16.13.1",
     "react-ga": "^3.1.2",
     "react-google-recaptcha": "^2.1.0",
-    "react-icons": "^4.2.0",
     "react-moment": "^0.9.7",
     "react-multi-carousel": "^2.6.5",
     "react-redux": "^7.2.4",

--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -5,7 +5,6 @@ import { ChevronDoubleLeft } from 'react-bootstrap-icons';
 import { useCookies } from 'react-cookie';
 import './Sidebar.scss'
 import DefaultAvatar from '../../asset/default-avatar.png';
-import { FaSignOutAlt, FaSignInAlt } from 'react-icons/fa';
 import { Button } from 'react-bootstrap';
 
 import { useAppSelector, useAppDispatch } from '../..//store/hooks';
@@ -56,19 +55,19 @@ const SideBar: FC = ({ children }) => {
             Catalogue
           </NavLink></li>
           {/* <li><NavLink to='/schedule' activeClassName='sidebar-active'>
-          <div> 
+          <div>
             <Icon name='clock outline' />
           </div>
           Schedule of Classes
         </NavLink></li> */}
           {/* <li><NavLink to='/zotistics' activeClassName='sidebar-active'>
-          <div> 
+          <div>
             <Icon name='chart bar outline' />
           </div>
           Zotistics
         </NavLink></li> */}
           {/* <li><NavLink to='/antalmanac' activeClassName='sidebar-active'>
-          <div> 
+          <div>
             <Icon name='calendar outline' />
           </div>
           AntAlmanac
@@ -80,7 +79,7 @@ const SideBar: FC = ({ children }) => {
             Peter's Roadmap
           </NavLink></li>
           {/* <li><NavLink to='/reviews' activeClassName='sidebar-active'>
-          <div> 
+          <div>
             <Icon name='thumbs up outline'/>
           </div>
           Reviews
@@ -92,13 +91,17 @@ const SideBar: FC = ({ children }) => {
       <div className='sidebar-login'>
         {isLoggedIn && <a href='/users/logout'>
           <Button variant='light'>
-            <FaSignOutAlt className='sidebar-login-icon' />
+            <span className='sidebar-login-icon'>
+              <Icon name='sign out' className='sidebar-login-icon' />
+            </span>
             Log Out
           </Button>
         </a>}
         {!isLoggedIn && <a href='/users/auth/google'>
           <Button variant='light'>
-            <FaSignInAlt className='sidebar-login-icon' />
+            <span className='sidebar-login-icon'>
+              <Icon name='sign in' className='sidebar-login-icon' />
+            </span>
             Log In
           </Button>
         </a>}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "baseUrl": "."
   },
   "include": [


### PR DESCRIPTION
Sooooo I tried running PeterPortal on my computer and I got this mysterious error:

```
Failed to compile.
Attempted import error: ‘FaSignInAlt' is not exported from 'react-icons/fa’.
```

Uh oh!! After some research and searching, I couldn’t find anything we’d done wrong in our setup, especially since this was working properly on other members’ computers (probably something slightly different with my setup or something). I eventually decided that instead of investigating further what the problem was, I’d swap the icons from using `react-icons` to using semantic UI (`import { Icon } from 'semantic-ui-react’`):

<img width="690" alt="Screen Shot 2021-11-15 at 19 18 49" src="https://user-images.githubusercontent.com/19882060/141943902-12111a30-ea1f-4203-921e-839dbdcef252.png">

_(spot the difference)_

Replacing these icons didn’t change the look of the site at all, and since those were the only two icons in the entire project that used `react-icons`, I was able to remove the dependency from the project altogether.