### PR TITLE
Fix option background color on review form

### DIFF
--- a/site/src/component/ReviewForm/ReviewForm.scss
+++ b/site/src/component/ReviewForm/ReviewForm.scss
@@ -26,7 +26,7 @@
       max-width: 150px;
     }
     option {
-      background-color: red;
+      background-color: white;
     }
     h5 {
       margin: 0 0 5px 0;


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #110 - review form option background color. 

## Description
I didn't see any contributing guidelines, so I'm not sure if contributions are limited to a specific community. However this turned out to be a simple CSS setting change, so hopefully it's OK... the background color of option was for some reason set to red. 

I actually can't replicate the bug on Chrome or Safari, because they force specific formatting onto options that are overriding the style sheet. However, it's very clear in the SCSS where the red background behavior is coming from. 
