### PR TITLE
Bump `node-sass` version to be compatible with Node 16+

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,6 @@
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
-    "node-sass": "^7.0.1",
     "react": "^16.13.1",
     "react-beautiful-dnd": "^13.0.0",
     "react-bootstrap": "^1.5.1",
@@ -74,6 +73,7 @@
     "@types/react-dom": "^17.0.9",
     "@types/react-redux": "^7.1.18",
     "@types/react-router-dom": "^5.1.8",
-    "@types/redux": "^3.6.0"
+    "@types/redux": "^3.6.0",
+    "sass": "^1.49.0"
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
-    "node-sass": "^4.14.1",
+    "node-sass": "^7.0.1",
     "react": "^16.13.1",
     "react-beautiful-dnd": "^13.0.0",
     "react-bootstrap": "^1.5.1",


### PR DESCRIPTION
`npm install` for the `site` directory didn’t complete on Node 16.x, but worked fine on Node 14.x. Turns out the issue was the version of the `node-sass` module we were using was only compatible up to Node 14! (image source: [node-sass npm page](https://www.npmjs.com/package/node-sass))

<img width="678" alt="Screen Shot 2022-01-24 at 16 59 32" src="https://user-images.githubusercontent.com/19882060/150890823-c349330a-453c-4915-a37d-f23cbd69b7a8.png">

I bumped the module to the current latest version (7.0.1), and ran the website to make sure changing the version didn’t break anything. Thankfully it didn’t!

UPDATE: turns out the `node-sass` module is deprecated and didn’t pass the GitHub Actions checks for AWS and Heroku, so I replaced it with the newer `sass` module per [this stackoverflow post](https://stackoverflow.com/questions/70281346/node-js-sass-version-7-0-0-is-incompatible-with-4-0-0-5-0-0-6-0-0)