### PR TITLE
No longer crashes when click on catalogue from professor search, adde…

### DIFF
--- a/site/src/component/SideBar/SideBar.tsx
+++ b/site/src/component/SideBar/SideBar.tsx
@@ -48,7 +48,7 @@ const SideBar: FC = ({ children }) => {
       {/* Links */}
       <div className='sidebar-links'>
         <ul>
-          <li><NavLink to='/search/courses' activeClassName='sidebar-active'>
+          <li><NavLink to='/' activeClassName='sidebar-active'>
             <div>
               <Icon name='list alternate outline' />
             </div>

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -46,3 +46,9 @@ code {
 .hide {
   display: none;
 }
+
+@font-face {
+  font-family: "revicons"; 
+  src: url("https://db.onlinewebfonts.com/t/0e979bd4a3c1c6ac788ed57ac569667f.eot"); 
+  src: url("https://db.onlinewebfonts.com/t/0e979bd4a3c1c6ac788ed57ac569667f.eot?#iefix") format("embedded-opentype"), url("https://db.onlinewebfonts.com/t/0e979bd4a3c1c6ac788ed57ac569667f.woff2") format("woff2"), url("https://db.onlinewebfonts.com/t/0e979bd4a3c1c6ac788ed57ac569667f.woff") format("woff"), url("https://db.onlinewebfonts.com/t/0e979bd4a3c1c6ac788ed57ac569667f.ttf") format("truetype"), url("https://db.onlinewebfonts.com/t/0e979bd4a3c1c6ac788ed57ac569667f.svg#revicons") format("svg"); 
+}


### PR DESCRIPTION
## Description
- Clicking on Catalogue now routes to the default page, which is course search
- Added a css import for the revicons font which should fix the missing arrows
