### PR TITLE
Fix cache invalidating when push out new version

### DIFF
--- a/site/public/index.html
+++ b/site/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-
+    <base href="/" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">


### PR DESCRIPTION
Site would often crash upon a new PR because the chrome cache was not being invalidated. Trying a fix from https://github.com/vuejs-templates/pwa/issues/165.