### PR TITLE
Made grade percentage on pie chart readable

### DIFF
--- a/site/src/component/GradeDist/Pie.tsx
+++ b/site/src/component/GradeDist/Pie.tsx
@@ -129,9 +129,16 @@ export default class Pie extends React.Component<PieProps> {
           borderWidth={1}
           borderColor={{ from: 'color', modifiers: [['darker', 0.2]] }}
           tooltip={(props: PieTooltipProps<Slice>) => (
-            <strong style={{ color: props.datum.color }}>
-              {props.datum.id}: {(props.datum.value / (this.total - this.totalPNP) * 100).toFixed(2)}%
-            </strong>
+            <div style={{ 
+              color: '#FFFFFF',
+              background: '#000000',
+              paddingLeft: '0.5em',
+              paddingRight: '0.5em'
+            }}>
+              <strong>
+                {props.datum.id}: {(props.datum.value / (this.total - this.totalPNP) * 100).toFixed(2)}%
+              </strong>
+            </div>
           )}
         />
         <div style={{ display: 'flex', textAlign: 'center', margin: '-235px' }}>


### PR DESCRIPTION
<!-- Title format: short pr description -->

## Description
<!-- Briefly explain the steps you took to complete this PR/solve the issue -->
Changed the color of the grade percentage shown when hovering over a section of the pie chart. Fixes issue #172.

## Screenshots

<!-- Include screenshot for front-end work -->
<!--
|screenshot|
|--|
|image|
-->

<!-- Include BEFORE/AFTER. Delete if N/A. (For visual front-end bug fixes) -->
<!--
|before|after|
|--|--|
|before image|after image|
-->
Before:
<img width="345" alt="before" src="https://user-images.githubusercontent.com/65315618/158960323-bb4366df-ba1b-45db-afc8-301b7f7ab2eb.png">
After:
<img width="357" alt="after" src="https://user-images.githubusercontent.com/65315618/158960338-90108f49-38cb-437e-a317-7b6323fc6285.png">

## Steps to verify/test this change:
Make sure the text is now readable.

## Todos:
- [ ] Write tests
- [ ] Write documentation
