### PR TITLE
Add year popup now shows on top of buttom

### DIFF
--- a/site/src/pages/RoadmapPage/AddYearPopup.tsx
+++ b/site/src/pages/RoadmapPage/AddYearPopup.tsx
@@ -27,7 +27,7 @@ const AddYearPopup: FC<AddYearPopupProps> = ({ placeholderYear }) => {
         <PlusCircleFill className="add-year-icon" />
         <div className="add-year-text">Add year</div>
       </Button>
-      <Overlay show={show} target={target} placement="bottom">
+      <Overlay show={show} target={target} placement="top">
         <Popover id=''>
           <Popover.Content>
             <Form>


### PR DESCRIPTION
Changed location of AddYear popup

## Description
I changed the Overlay Component in AddYearPopup.tsx to show on top of its target, rather than the bottom

## Screenshots
![image](https://user-images.githubusercontent.com/80178962/159080939-11ea23f0-84a4-4ec6-9ad9-ed081878b0cf.png)

## Steps to verify/test this change:
Visual change

## Todos:
Might still overflow in weird edge cases. Needs mobile testing
